### PR TITLE
feat: Add elasticity

### DIFF
--- a/EMissionCompatibility.js
+++ b/EMissionCompatibility.js
@@ -635,7 +635,8 @@ export async function StartTracking() {
       // Geolocation Config
       desiredAccuracy: BackgroundGeolocation.DESIRED_ACCURACY_HIGH,
       showsBackgroundLocationIndicator: false, //Displays a blue pill on the iOS status bar when the location services are in use in the background (if the app doesn't have 'always' permission, the blue pill will always appear when location services are in use while the app isn't focused)
-      distanceFilter: 10,
+      distanceFilter: 20,
+      elasticityMultiplier: 3,
       locationUpdateInterval: 10000, // Only used if on Android and if distanceFilter is 0
       stationaryRadius: 200, // Minimum, but still usually takes 200m
       // Activity Recognition


### PR DESCRIPTION
The elasticity parameter is useful to calibrate the tracking frequency, used with the distanceFilter parameter.

From the doc:
> distanceFilter is auto-scaled by rounding speed to the nearest 5 m/s
and adding distanceFilter meters for each 5 m/s increment.

The formula is the following:
`roundedSpeed * distanceFilter * elasticityMultipiler`

For instance, at highway speed of 27 m/s (~100km/h) with a configured distanceFilter of 20 and an elasticty of 3, we have: `round(27, 5) / 5 * 20 * 3 = 7 * 20 * 3 = 420`

Meaning we'll capture a point every 402 meters.

This calibration is a trade-off between precision and battery consumption. We also suspect that setting a too intensive tracking might result into degrading the sensors availability on iOS: https://github.com/transistorsoft/react-native-background-geolocation/issues/1812