### PR TITLE
fix: Headless

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@ import { AppRegistry } from 'react-native'
 import BackgroundGeolocation from 'react-native-background-geolocation'
 
 import App from './App'
+import { name as appName } from './app.json'
+import { Log } from './geolocation/helpers'
 import {
-  Log,
   handleMotionChange,
   handleConnectivityChange
 } from './geolocation/services'
-import { name as appName } from './app.json'
 
 AppRegistry.registerComponent(appName, () => App)
 


### PR DESCRIPTION
Android headless mode was broken because of wrong imports since the refacto