### PR TITLE
Fix readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,11 @@ If you want to update cozy-flagship-app, run `git submodule update --remote cozy
 
 Visualize your GeoJSON trips stored in `public/geojson.json`.
 
-
 ## Run
-
 
 ```sh
 # Only first time
-cp tools/trip-viz/public/geojson.json.sample cp tools/trip-viz/public/geojson.json
+cp tools/trip-viz/public/geojson.json.sample tools/trip-viz/public/geojson.json
 
 # Run server
 yarn server-viz
@@ -35,22 +33,22 @@ yarn server-viz
 
 The file in which you should store the GeoJSON is `public/geojson.json`.
 
-
 The simplest method to populate this file is running the script
+
 ```sh
 ./tools/data-viz/scripts/get-emission-geojson.sh <userID> <date> [server_url]
 ```
 
-This will fetch the trips stored in the given `server_url` (default is http://localhost:8080), 
+This will fetch the trips stored in the given `server_url` (default is http://localhost:8080),
 on the given user and date (format YYYY-MM-DD).
 
 ### Data format
 
 There are 2 supported formats for the geojson.json file, depending on if you want to display one or multiple trips:
 
-#### Single trip
+#### Single trip
 
-This corresponds to a standard GeoJSON, for instance: 
+This corresponds to a standard GeoJSON, for instance:
 
 ```json
 {
@@ -89,10 +87,9 @@ This corresponds to a standard GeoJSON, for instance:
 }
 ```
 
+#### Multi trips
 
-#### Mutli trips
-
-The format is the following and corresponds to the raw response of an openpath server on `https://<url>/timeline/getTrips/<YYYY-mm-dd>`: 
+The format is the following and corresponds to the raw response of an openpath server on `https://<url>/timeline/getTrips/<YYYY-mm-dd>`:
 
 ```json
 {
@@ -109,7 +106,6 @@ The format is the following and corresponds to the raw response of an openpath s
   ]
 }
 ```
-
 
 # Simulation
 
@@ -209,7 +205,8 @@ Here we detail the plugin data models
 }
 ```
 
-⚠️ On Android, this value is not relevant and is always 100. 
+> [!WARNING]  
+> On Android, this value is not relevant and is always 100.
 
 ### Activity types
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Edit the variables at the bottom of `tools/simulation/index.js` to your convenie
 
 ```sh
 cd tools/simulation
+yarn
 node index.js
 ```
 


### PR DESCRIPTION
Hi, thanks for your great work !

Here are a few fixes on the README install doc, also formatted the document so the headings are correctly displayed.
I converted the warning to GFM thanks to https://github.com/orgs/community/discussions/16925 


Note: The error encountered during the simulation run (prior to running `yarn` in the subfolder): 
```
node:internal/errors:484
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'date-fns' imported from /Users/anthony/projects/workspace_contrib/CozyGPSMemory/tools/simulation/index.js
    at new NodeError (node:internal/errors:393:5)
    at packageResolve (node:internal/modules/esm/resolve:860:9)
    at moduleResolve (node:internal/modules/esm/resolve:909:20)
    at defaultResolve (node:internal/modules/esm/resolve:1124:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:841:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:40)
    at link (node:internal/modules/esm/module_job:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```